### PR TITLE
Password input field: show/hide password with icon

### DIFF
--- a/src/arena-mobile-ui/components/PasswordInput/index.js
+++ b/src/arena-mobile-ui/components/PasswordInput/index.js
@@ -1,0 +1,43 @@
+import React, {useState} from 'react';
+import {Text, View, TextInput} from 'react-native';
+
+import baseStyles from 'arena-mobile-ui/styles';
+
+import {TouchableIcon} from '../TouchableIcons';
+
+import styles from './styles';
+
+const icons = {
+  passwordVisible: 'eye-outline',
+  passwordHidden: 'eye-off-outline',
+};
+
+const PasswordInput = ({title, autoFocus = false, ...otherProps}) => {
+  const [passwordVisible, setPasswordVisible] = useState(false);
+
+  const togglePasswordVisible = () => {
+    setPasswordVisible(!passwordVisible);
+  };
+
+  const rightIcon = passwordVisible
+    ? icons.passwordVisible
+    : icons.passwordHidden;
+
+  return (
+    <View style={styles.container}>
+      <Text style={[baseStyles.textStyle.text]}>{title}</Text>
+      <View style={styles.inputContainer}>
+        <TextInput
+          style={styles.input}
+          autoFocus={autoFocus}
+          selectTextOnFocus={true}
+          secureTextEntry={!passwordVisible}
+          {...otherProps}
+        />
+        <TouchableIcon onPress={togglePasswordVisible} iconName={rightIcon} />
+      </View>
+    </View>
+  );
+};
+
+export default PasswordInput;

--- a/src/arena-mobile-ui/components/PasswordInput/styles.js
+++ b/src/arena-mobile-ui/components/PasswordInput/styles.js
@@ -1,0 +1,22 @@
+import {StyleSheet} from 'react-native';
+
+import inputStyles from '../Input/styles';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  inputContainer: {
+    ...inputStyles.input,
+    width: '100%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 0,
+    paddingVertical: 2,
+  },
+  input: {
+    width: '95%',
+  },
+});
+
+export default styles;

--- a/src/arena-mobile-ui/components/PasswordInput/styles.js
+++ b/src/arena-mobile-ui/components/PasswordInput/styles.js
@@ -8,14 +8,14 @@ const styles = StyleSheet.create({
   },
   inputContainer: {
     ...inputStyles.input,
-    width: '100%',
+    flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
-    padding: 0,
+    padding: 4,
     paddingVertical: 2,
   },
   input: {
-    width: '95%',
+    flex: 1,
   },
 });
 

--- a/src/screens/ConnectionSettings/screen.js
+++ b/src/screens/ConnectionSettings/screen.js
@@ -14,6 +14,7 @@ import Card from 'arena-mobile-ui/components/Card';
 import Header from 'arena-mobile-ui/components/Header';
 import Input from 'arena-mobile-ui/components/Input';
 import Layout from 'arena-mobile-ui/components/Layout';
+import PasswordInput from 'arena-mobile-ui/components/PasswordInput';
 import QRScanner, {
   useQRScanner,
   QRScannerButton,
@@ -122,11 +123,10 @@ const ConnectionSettings = () => {
                 onChangeText={onChangeText('username')}
                 value={formData?.username || username}
               />
-              <Input
+              <PasswordInput
                 title={t('ConnectionSettings:access_info_fields.password')}
                 onChangeText={onChangeText('password')}
                 value={formData?.password || password}
-                secureTextEntry={true}
               />
 
               <Button


### PR DESCRIPTION
To show the password show/hide icon inside the input field, I'm using a View that wraps the input field and the icon and giving to the View (almost) the same style as the "normal" input field.