### PR TITLE
Removed  "only published" surveys filtering (already done by apiSurveys.getSurveys)

### DIFF
--- a/src/state/surveys/hooks/index.js
+++ b/src/state/surveys/hooks/index.js
@@ -18,11 +18,9 @@ export const useRemoteSurveys = () => {
       setLoading(true);
       const _surveys = await apiSurveys.getSurveys({serverUrl});
       setSurveys(
-        _surveys
-          .filter(survey => survey.status === 'PUBLISHED')
-          .sort(
-            (sa, sb) => -moment(sa.dateModified).diff(moment(sb.dateModified)),
-          ),
+        _surveys.sort(
+          (sa, sb) => -moment(sa.dateModified).diff(moment(sb.dateModified)),
+        ),
       );
     } catch (e) {
       setSurveys([]);


### PR DESCRIPTION
Not-published surveys are already excluded during surveys fetching.
The filtering on status excludes published surveys with changes (PUBLISHED-DRAFT status).