### PR TITLE
Removed "only published" surveys filtering (already done by apiSurveys.getSurveys) 

### DIFF
--- a/src/infra/api/index.js
+++ b/src/infra/api/index.js
@@ -22,7 +22,7 @@ export default ({serverUrl = SERVER_URL}) => {
       method,
       ...(body ? {body: JSON.stringify(body)} : {}),
       ...(body ? {data: JSON.stringify(body)} : {}),
-      ...(params ? {params: JSON.stringify(params)} : {}),
+      ...(params ? {params} : {}),
       headers: {
         'Content-Type': contentType || CONTENT_TYPES.json,
       },

--- a/src/state/records/api/api.js
+++ b/src/state/records/api/api.js
@@ -4,9 +4,8 @@ import * as fs from 'infra/fs';
 const getRecords = async ({serverUrl, surveyId, cycle}) => {
   try {
     const res = await API({serverUrl}).get({
-      path: `api/survey/${surveyId}/records?${new URLSearchParams({
-        cycle,
-      })}`,
+      path: `api/survey/${surveyId}/records`,
+      params: {cycle},
     });
     return res?.data;
   } catch (error) {
@@ -18,9 +17,8 @@ const getRecords = async ({serverUrl, surveyId, cycle}) => {
 const getRecord = async ({serverUrl, surveyId, recordUuid}) => {
   try {
     const res = await API({serverUrl}).get({
-      path: `api/survey/${surveyId}/record/?${new URLSearchParams({
-        recordUuid,
-      })}`,
+      path: `api/survey/${surveyId}/record`,
+      params: {recordUuid},
     });
 
     return res?.data;

--- a/src/state/surveys/hooks/index.js
+++ b/src/state/surveys/hooks/index.js
@@ -18,11 +18,9 @@ export const useRemoteSurveys = () => {
       setLoading(true);
       const _surveys = await apiSurveys.getSurveys({serverUrl});
       setSurveys(
-        _surveys
-          .filter(survey => survey.status === 'PUBLISHED')
-          .sort(
-            (sa, sb) => -moment(sa.dateModified).diff(moment(sb.dateModified)),
-          ),
+        _surveys.sort(
+          (sa, sb) => -moment(sa.dateModified).diff(moment(sb.dateModified)),
+        ),
       );
     } catch (e) {
       setSurveys([]);


### PR DESCRIPTION
Not-published surveys are already excluded during surveys fetching.
The filtering on status excludes published surveys with changes (PUBLISHED-DRAFT status).
I think there was something wrong in the way the params object was passed to axios get... e.g. in the surveys fetch the draft=true param was ignored,